### PR TITLE
Export useSubmit hook - fixes #7

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react'
 
-function Form(props) {
-  const onSubmitForm = useCallback(event => {
+function useSubmit(props) {
+  return useCallback(event => {
     event.preventDefault()
     event.stopPropagation()
 
@@ -17,6 +17,10 @@ function Form(props) {
 
     onSubmit(fields)
   }, [])
+}
+
+function Form(props) {
+  const onSubmitForm = useSubmit(props)
   const { children } = props
 
   return (
@@ -42,5 +46,5 @@ function Input(props) {
 }
 
 module.exports = {
-  Form, Input,
+  Form, Input, useSubmit,
 }


### PR DESCRIPTION
Use submit as `useSubmit` hook, without the need to use it inside the Form component.